### PR TITLE
adding codes for generating saltwater_intrusion plot

### DIFF
--- a/scripts/preprocessing/drought_risk.Rmd
+++ b/scripts/preprocessing/drought_risk.Rmd
@@ -12,7 +12,7 @@ library(ipumsr)
 library(plyr)
 library(dplyr)
 library(readxl)
-data <- read_xlsx("data/final_results_dissemination_NDINDC.xlsx")
+data <- read_xlsx("~/Desktop/WaterReuseDSSG2024/data/final_results_dissemination_NDINDC.xlsx")
 ```
 
 ## Processing

--- a/scripts/preprocessing/local_activism.Rmd
+++ b/scripts/preprocessing/local_activism.Rmd
@@ -7,6 +7,15 @@ date: "2024-06-26"
 # Introduction
 Procedural equity refers to the degree to which stakeholders can influence decision-making process around the policy outcome. In this project, we focus on procedural equity around water reuse. To proxy this, this script introduces two approaches. First, Census data provides information about individuals who are involved in local civic organizations. Second, by flipping the unit of analysis, County Business Pattern provides information about the number of civic organizations and water-relevant. 
 
+## document padding for identifiers at county level
+README markdown for processing countyfips should be X number of characters long.
+or write that into a function
+  features of this identifier that needs to be consistent 
+  ways this can be constructed by changing 
+
+  
+
+
 ## Census data on Volunteering and Civic Life
 This script is intended to 1) download the "cps_00002.dat" dataset and 2) clean the data such that it can be merged with the other files at the facility level. The purpose of using this dataset is to proxy the degree to which civic society is involved in activism at local agendas. 
 Note that all of these datasets are publicly available at the [IPUMS](https://cps.ipums.org/cps/).
@@ -111,8 +120,6 @@ I created a new variable called "water" which is coded 1 if NAICS code is water-
 cbp_data has a new variable called "county_fips" which turns fipstate into a numeric variable and append that with fipscty (FIPS county code). This process is only to make it compatible with county-level map's identifer variable which takes a form of "state_id + county_id." 
 
 ```{r load cbp data}
-
-cbp <- read_csv("data/CBP2022/CBP2022.CB2200CBP-Data.csv") 
 cbp <- read_csv("data/cbp22co.txt") 
 cbp <- cbp %>%
   dplyr::mutate(water = ifelse(naics %in% c("2213//", #water, sewage system
@@ -137,7 +144,7 @@ cbp <- cbp %>%
 
 
 cbp_data <- cbp %>%
-  mutate(county_fips = as.numeric(fipstate) * 1000 + as.numeric(fipscty))
+  mutate(county_fips = paste(fipstate, fipscty, sep=""))
 
 #water sector
 cbp_water <- cbp_data %>%

--- a/scripts/preprocessing/saltwater_intrusion.Rmd
+++ b/scripts/preprocessing/saltwater_intrusion.Rmd
@@ -1,0 +1,103 @@
+---
+title: "Salt Water Intrusion"
+output: html_document
+date: "2024-07-01"
+---
+
+This script is intended to map "salt water intrusion" data onto the coastline shapefile.
+
+## Introduction
+
+- ComID is about unique feature identifier in NHDPlusV2.
+- REACHCODE is a common identifier for Catchment_CONUS_coastline.shp file and Saltwater Intrusion dataset.
+
+```{r download}
+library(ipumsr)
+library(plyr)
+library(dplyr)
+library(readr)
+library(sf)
+library(xml2)
+
+data <- read_csv("~/Desktop/WaterReuseDSSG2024/data/SGD_Coastal_Vulnerabilities.csv", 
+                 col_types = cols(.default = "c"))
+map <- read_sf("~/Downloads/Catchment_CONUS_coastline.shp")
+
+
+data$REACHCODE <- ifelse(nchar(data$REACHCODE) < 14, 
+                          paste0("0", data$REACHCODE), 
+                          data$REACHCODE)
+ 
+# map$REACHCODE <- ifelse(nchar(map$REACHCODE) < 14, 
+#                          paste0("0", map$REACHCODE), 
+#                          map$REACHCODE)
+
+
+#I'm aggregating ComID-level observations up to REACHCODE level. This is because "map" is at the REACHCODE level.
+
+data <- data %>%
+  group_by(REACHCODE, REGION) %>%
+  summarize(SWIVULN = sum(as.numeric(SWIVULN)))
+
+sum(map$REACHCODE%in% data$REACHCODE)
+sum(data$REACHCODE%in% map$REACHCODE)
+
+hold <- map[map$REACHCODE %in% data$REACHCODE[-which(data$REGION %in% c("TX", "CA","PN"))],]
+
+
+plot_usmap("counties", color = "gray80") + 
+  geom_sf(data = plot_data, aes(fill = SWIVULN))
+
+
+usmap <- usmap_transform(map)
+
+plot_data <- usmap %>%
+  left_join(data, by = c("REACHCODE"))
+
+plot_usmap("counties", color = "gray80") + 
+  geom_sf(data = plot_data, color = "lightblue", size = 0.2) +
+  geom_point(data = plot_data,
+    aes(color = SWIVULN, size = SWIVULN, geometry = geometry),
+    alpha = 0.2,
+    color = "red",
+    stat = "sf_coordinates"
+  ) +
+  scale_size_continuous(name = "Saltwater Vulnerability",
+                        labels = scales::comma_format(),
+                        range = c(0.01, 7)) + 
+  scale_color_gradient(name = "Saltwater Vulnerability",
+                       low = "bisque", high = "red") +
+  theme(legend.position = "bottom") +
+  labs(title = "Saltwater Vulnerability") +
+  theme(text = element_text(family = "Times New Roman"))
+
+```
+
+# Loop through all variables once the above is done. 
+
+```{r}
+variables_to_loop <- names(plot_data)[9:length(names(plot_data))]
+
+plot_list <- list()
+
+for (variable in variables_to_loop) {
+  plot <- ggplot(data = plot_data) +
+    geom_sf(color = "blue", size = 1) +  
+    geom_sf(aes_string(color = variable)) +  
+    scale_color_continuous(name = variable) +  
+    scale_size_continuous(name = "",
+                          labels = scales::comma_format(),
+                          range = c(0.1, 10)) +  
+    labs(title = variable)  
+  
+  plot_list[[variable]] <- plot
+}
+
+
+print(plot_list[[1]])
+
+for (i in seq_along(plot_list)) {
+  ggsave(paste0("plot_", names(plot_list)[i], ".png"), plot_list[[i]], width = 8, height = 6)
+}
+
+```


### PR DESCRIPTION
I am adding a new markdown file that plots saltwater intrusion vulnerability onto the shoreline map. 
This can be used as a starting point for generalizing the use of external shape files.