### PR TITLE
23 create map utils

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,2 +1,0 @@
-default:
-  datasets_dir: "/Users/jihyeonbae/Desktop/WaterReuseDSSG2024/data"

--- a/map_utils/map_utils.R
+++ b/map_utils/map_utils.R
@@ -14,49 +14,222 @@ check_compatibility <- function(data, shapefile, data_key, shape_key) {
   return (check_result)
 }
 
-plot_percentile <- function(data, variable, caption, title,
-                            percentile=0.95,
-                            low_color = "white", high_color = "red",
-                            na_color = "gray"){
-  percentiles <- quantile(data[[variable]], probs=c(0, percentile), na.rm=TRUE)
+plot_absolute <- function(data, 
+                          variable, 
+                          caption, 
+                          title,
+                          low_color = "white", 
+                          high_color = "red",
+                          na_color = "gray",
+                          map_font = "Arial" 
+                      ){
   
-  plot_data_variable <- ggplot(data)+
+  # Inputs:
+  # - data (dataframe) - expects a dataframe containing a geometry
+    # and a variable of interest. Usually, this dataframe will result
+    # from merging (1) a raw data file, indexed by a geographic region
+    # identifier like FIPS, with (2) a shapefile that specifies the
+    # geographic regions in question
+  
+  # - variable (string) - a string containing the NAME of the column in 
+    # data that contains the variable that should be used to make the map
+
+  # - caption (string) - a string defining the caption that appears
+    # at the bottom right of the map figure
+  
+  # - title (string) - the map title
+  
+  # - low_color, high_color, na_color (strings) - the colors desigating
+    # the lowest and highest values of variable, respectively, and the 
+    # color that should indicate missing data
+  
+  # map_font (string) - font in the title, caption, legends
+  
+  ###################################################################
+  
+  # Outputs:
+  # - a ggplot2 object mapping the shapes defined in the dataset and
+    # color-coding them according to the unadjusted value of variable
+  
+  
+  plot_data_variable <- ggplot(data) +
     geom_sf(mapping = aes_string(fill = variable)) +
     scale_fill_gradient(name = variable, 
                         label = scales::comma_format(),
-                        low=low_color,
-                        high=high_color,
+                        low = low_color,
+                        high = high_color,
                         na.value = na_color,
-                        limits = percentiles,
                         breaks = scales::pretty_breaks(n = 5)) + 
     labs(title = title,
          caption = caption) +
-    theme(text = element_text(family = "Times New Roman"))
+    theme(text = element_text(family = map_font))
   
   return(plot_data_variable)
   
 }
 
-map_chloropleth <- function(data, shapefile, data_key, shape_key, value) {
+plot_percentile <- function(data, 
+                            variable, 
+                            caption, 
+                            title,
+                            low_color = "white", 
+                            high_color = "red",
+                            na_color = "gray",
+                            map_font = "Arial") {
+  
+  # Inputs:
+  # - data (dataframe) - expects a dataframe containing a geometry
+  # and a variable of interest. Usually, this dataframe will result
+  # from merging (1) a raw data file, indexed by a geographic region
+  # identifier like FIPS, with (2) a shapefile that specifies the
+  # geographic regions in question
+  
+  # - variable (string) - a string containing the NAME of the column in 
+  # data that contains the variable that should be used to make the map
+  
+  # - caption (string) - a string defining the caption that appears
+  # at the bottom right of the map figure
+  
+  # - title (string) - the map title
+  
+  # - low_color, high_color, na_color (strings) - the colors desigating
+  # the lowest and highest values of variable, respectively, and the 
+  # color that should indicate missing data
+  
+  # map_font (string) - font in the title, caption, legends
+  
+  ###################################################################
+  
+  # Outputs:
+  # - a ggplot2 object mapping the shapes defined in the dataset and
+    # color-coding them according to the value of variable; instead of
+    # plotting the RAW value of variable, this function coverts them
+    # to percentile scores and maps the percentile scores
+  
+  ecdf_function <- ecdf(data[[variable]])
+  
+  percentiles <- ecdf_function(data[[variable]])
+  
+  plot_data_variable <- ggplot(data) +
+    geom_sf(mapping = aes_string(fill = percentiles)) +
+    scale_fill_gradient(name = paste(variable, "\n(percentile)"), 
+                        label = scales::comma_format(),
+                        low = low_color,
+                        high = high_color,
+                        na.value = na_color,
+                        limits = c(min(percentiles), 
+                                   max(percentiles)),
+                        breaks = scales::pretty_breaks(n = 5)) + 
+    labs(title = title,
+         caption = caption) +
+    theme(text = element_text(family = map_font))
+  
+  return(plot_data_variable)
+  
+}
+
+map_chloropleth <- function(data, 
+                            shapefile, 
+                            data_key, 
+                            shape_key, 
+                            variable, 
+                            map_title="Title", 
+                            map_caption="Caption",
+                            map_percentile=FALSE, 
+                            low_color = "white", 
+                            high_color = "red",
+                            na_color = "gray",
+                            map_font = "Arial") {
+  
+  # Inputs:
+  # - data (dataframe) - expects a dataframe containing a variable of 
+    # interest, indexed by a geographic region identifier like FIPS
+  
+  # - shape (dataframe) a shapefile that specifies the
+    # geographic regions in question; must contain a 'geometry' column
+  
+  # - data_key (string) - a string that contains the NAME of column in
+    # data that should be used to merge it with the shapefile. This
+    # should be something like "FIPS"
+  
+  # - shape_key (string) - a string that contains the NAME of column in
+    # the shapefile that should be used to merge it with the data. This
+    # should be something like "FIPS" 
+  
+  # - variable (string) - a string containing the NAME of the column in 
+    # data that contains the variable that should be used to make the map
+  
+  # - map_title (string) - the map title
+  
+  # - map_caption (string) - a string defining the caption that appears
+  # at the bottom right of the map figure
+  
+  # - map_percentile (boolean) - whether the map should display raw values
+  # of variable (=FALSE, default) or show which percentile of the
+  # data distribution the geographic unit in question falls into (=TRUE)
+  
+  # - low_color, high_color, na_color (strings) - the colors designating
+  # the lowest and highest values of variable, respectively, and the 
+  # color that should indicate missing data
+  
+  # map_font (string) - font in the title, caption, legends
+  
+  ###################################################################
+  
+  # Outputs:
+  # - a ggplot2 object mapping the shapes defined in the dataset and
+  # color-coding them according to the value of variable; instead of
+  # plotting the RAW value of variable, this function coverts them
+  # to percentile scores and maps the percentile scores
+  
   
   if (check_compatibility(data, shapefile, data_key, shape_key) == FALSE) {
     warning("This dataset & shapefile seem incompatible. 
             Please check that column names match key names and that 
             keys in data & shapefile have the same type")
   }
+  
   if (data_key != shape_key) {
     
-    data_sf <- shapefile %>% left_join(data, by = c(data_key, shape_key)) %>% 
-      mutate(value = as.numeric(value))
+    data_sf <- shapefile %>% left_join(data, by = c(data_key, shape_key))
+    
+    data[[variable]] <- as.numeric(data[[variable]])
   
   }
   
   else {
-    data_sf <- shapefile %>% left_join(data, by = data_key) %>% 
-      mutate(value = as.numeric(value))
+    
+    data_sf <- shapefile %>% left_join(data, by = data_key)
+    
+    data[[variable]] <- as.numeric(data[[variable]])
+    
   }
   
-  plot_percentile(data_sf)
+  if (map_percentile == TRUE) {
+    
+    plot_percentile(data_sf, 
+                    variable, 
+                    title = map_title, 
+                    caption = map_caption,
+                    low_color = low_color, 
+                    high_color = high_color,
+                    na_color = na_color,
+                    map_font = map_font)
+  
+    }
+  
+  else {
+    
+    plot_absolute(data_sf, 
+                  variable, 
+                  title = map_title, 
+                  caption = map_caption,
+                  low_color = low_color, 
+                  high_color = high_color,
+                  na_color = na_color,
+                  map_font = map_font)
+  
+    }
 }
 
 

--- a/map_utils/map_utils.R
+++ b/map_utils/map_utils.R
@@ -9,7 +9,54 @@ check_compatibility <- function(data, shapefile, data_key, shape_key) {
   
   check_result <- data_key %in% names(data) && 
     shape_key %in% names(shapefile) && 
-    type(data_key) == typeof(shape_key)
+    typeof(data_key) == typeof(shape_key)
   
   return (check_result)
 }
+
+plot_percentile <- function(data, variable, caption, title,
+                            percentile=0.95,
+                            low_color = "white", high_color = "red",
+                            na_color = "gray"){
+  percentiles <- quantile(data[[variable]], probs=c(0, percentile), na.rm=TRUE)
+  
+  plot_data_variable <- ggplot(data)+
+    geom_sf(mapping = aes_string(fill = variable)) +
+    scale_fill_gradient(name = variable, 
+                        label = scales::comma_format(),
+                        low=low_color,
+                        high=high_color,
+                        na.value = na_color,
+                        limits = percentiles,
+                        breaks = scales::pretty_breaks(n = 5)) + 
+    labs(title = title,
+         caption = caption) +
+    theme(text = element_text(family = "Times New Roman"))
+  
+  return(plot_data_variable)
+  
+}
+
+map_chloropleth <- function(data, shapefile, data_key, shape_key, value) {
+  
+  if (check_compatibility(data, shapefile, data_key, shape_key) == FALSE) {
+    warning("This dataset & shapefile seem incompatible. 
+            Please check that column names match key names and that 
+            keys in data & shapefile have the same type")
+  }
+  if (data_key != shape_key) {
+    
+    data_sf <- shapefile %>% left_join(data, by = c(data_key, shape_key)) %>% 
+      mutate(value = as.numeric(value))
+  
+  }
+  
+  else {
+    data_sf <- shapefile %>% left_join(data, by = data_key) %>% 
+      mutate(value = as.numeric(value))
+  }
+  
+  plot_percentile(data_sf)
+}
+
+

--- a/map_utils/map_utils.R
+++ b/map_utils/map_utils.R
@@ -1,4 +1,7 @@
-check_compatibility <- function(data, shapefile, data_key, shape_key) {
+check_compatibility <- function(data, 
+                                shapefile, 
+                                data_key, 
+                                shape_key) {
   
   # Two checks are needed:
   # - data_key is a column in data & shape_key is a column in shapefile

--- a/scripts/preprocessing/CountyMappingv2.Rmd
+++ b/scripts/preprocessing/CountyMappingv2.Rmd
@@ -39,14 +39,16 @@ filename <- "final_results_dissemination_NDINDC.xlsx"
 filepath <- paste0(dataset_dir, filename)
 
 data <- read_xlsx(filepath, sheet=1) %>% 
-  mutate(FIPS = as.character(FIPS))
+  mutate(FIPS = as.character(FIPS)) %>% 
+  mutate(FIPS = sub("^0+", "", FIPS))
 ```
 
 ```{r}
 
 ## TO DO: consider how to deal with leading zeros
 counties <- counties %>% 
-  rename(FIPS = county_fips)
+  rename(FIPS = county_fips) %>%
+  mutate(FIPS = sub("^0+", "", FIPS))
 ```
 
 ```{r}
@@ -85,6 +87,16 @@ plot_percentile(data = data_sf,
                 caption = "NDI is...")
 ```
 
+
 ```{r}
-map_chloropleth(data, counties, "FIPS", "FIPS", "NDI")
+map_chloropleth(data, 
+                counties, 
+                "FIPS", 
+                "FIPS", 
+                "NDI",
+                map_percentile = TRUE)
+```
+
+```{r}
+
 ```

--- a/scripts/preprocessing/CountyMappingv2.Rmd
+++ b/scripts/preprocessing/CountyMappingv2.Rmd
@@ -84,3 +84,7 @@ plot_percentile(data = data_sf,
                 title = "NDI by county", 
                 caption = "NDI is...")
 ```
+
+```{r}
+map_chloropleth(data, counties, "FIPS", "FIPS", "NDI")
+```


### PR DESCRIPTION
Creates a function that allows user to pass in a dataset indexed by a geographical identifier and a shapefile that defines those geographical areas. (For example, this could be a table of `county_fips`, which each county associated to a drought risk, and a shapefile that tells ggplot2 what the counties look like.) 

This function merges those two datasets and generates a chloropleth map, coloring in the geographical units based on the values of a (user-specified) variable in the dataset. Associated helper functions are included in this PR.