### PR TITLE
Issue #52 Add function that identifies key columns and pads 0 when needed

### DIFF
--- a/scripts/utility_function/key_identifier.R
+++ b/scripts/utility_function/key_identifier.R
@@ -1,0 +1,28 @@
+# input: shape file and data
+# output: a list of two dataframes that are padded with 0s.
+# list[[1]] is transformed shapefile and list[[2]] is transformed dataset.
+# This will allow the user to identify a list of key variables while merging and preprocess key variables.
+
+identify_key <- function(shape, data) {
+  key <- intersect(names(shape), names(data))
+  key <- key[grep("^[0-9]", key)]
+  
+  for (k in key) {
+    shape[[k]] <- as.character(shape[[k]])
+    data[[k]] <- as.character(data[[k]])
+    
+    max_len <- max(nchar(shape[[k]]), nchar(data[[k]]))
+    shape[[k]] <- str_pad(shape[[k]], width = max_len, side = "left", pad = "0")
+    data[[k]] <- str_pad(data[[k]], width = max_len, side = "left", pad = "0")
+    
+    print(summary(nchar(shape[[k]])))
+    print(summary(nchar(data[[k]])))
+  }
+  
+  return(list(shape, data))
+}
+
+# Example usage:
+#output <- identify_key(shape = map, data = data)
+#shape <- output[[1]]
+#data <- output[[2]]


### PR DESCRIPTION
#52 
The goal of this task is to create a general function that checks if there is a common identifier in both shape file and dataset, correct it if not, and construct one from constituent parts.

This function will do following things.

Print out common column names that will be keys when merging shape file and data.
Check if identifiers in each data is in the same format.
Filter key variables that start with digits, not characters.
Pad with zero when necessary.
Input: shape file, data (which contains variables of interest)
Output: a list of two elements. list[[1]] is a transformed shape file, and list[[2]] is a transformed dataset.

location: "scripts/utility_functions"