### PR TITLE
fixing some sequence mix-up

### DIFF
--- a/code/crosswalk/crosswalk_spatial.R
+++ b/code/crosswalk/crosswalk_spatial.R
@@ -1,7 +1,5 @@
-# setwd(config::get("home_path"))
-
-source(paste0(root_dir, "/code/crosswalk/crosswalk_geom.R"))
-source(paste0(root_dir,"/code/crosswalk/crosswalk_raster.R"))
+#source(paste0(root_dir, "/code/crosswalk/crosswalk_geom.R"))
+#source(paste0(root_dir,"/code/crosswalk/crosswalk_raster.R"))
 
 
 crosswalk_spatial <- function(data, target, location_columns = NULL, extensive = FALSE, join_method = NULL) {

--- a/geo-ndxr/create_index_tutorial.md
+++ b/geo-ndxr/create_index_tutorial.md
@@ -33,6 +33,8 @@ pacman::p_load(tigris, tidyverse, dplyr, sf, usmap, ggplot2, naniar, raster, ter
 
 
 #Source GeoNdxR crosswalk functions. Find documentation for these functions linked in the GitHub README. 
+source(paste0(home_path, "/code/crosswalk/crosswalk_geom.R"))
+source(paste0(home_path,"/code/crosswalk/crosswalk_raster.R"))
 source(paste0(home_path,"/code/crosswalk/crosswalk_spatial.R"))
 source(paste0(home_path,"/code/crosswalk/crosswalk_census.R"))
 source(paste0(home_path,"/code/crosswalk/crosswalk_id.R"))


### PR DESCRIPTION
some of the fundamental functions were omitted from the source list in the tutorial document. 
I also commented out source functions for crosswalk_geom and crosswalk_raster since the user might have a different name for their own home directory. Instead, the updated tutorial asks them to source these two functions explicitly. 
